### PR TITLE
Fix FILTER_VALIDATE_BOOLEAN variable

### DIFF
--- a/src/Core/Gateway/PixGateway.php
+++ b/src/Core/Gateway/PixGateway.php
@@ -380,7 +380,7 @@ class PixGateway extends WC_Payment_Gateway
 		$settings = CoreConnector::settings()->get('gateway', new KeyingBucket());
 		
 		if ( $key === 'enabled' )
-		{ $value = \filter_var($value, \FILTER_VALIDATE_BOOL); }
+		{ $value = \filter_var($value, \FILTER_VALIDATE_BOOLEAN); }
 
 		$settings->set($key, $value);
 		


### PR DESCRIPTION
```php
PHP Fatal error:  Uncaught Error: Undefined constant 'FILTER_VALIDATE_BOOL' in pix-por-piggly/src/Core/Gateway/PixGateway.php:383
Stack trace:
#0 woocommerce/includes/class-wc-ajax.php(3095): Piggly\\WooPixGateway\\Core\\Gateway\\PixGateway->update_option('enabled', 'yes')
#1 /var/www/html/wp-includes/class-wp-hook.php(303): WC_AJAX::toggle_gateway_enabled('')
#2 /var/www/html/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters('', Array)
#3 /var/www/html/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#4 /var/www/html/wp-admin/admin-ajax.php(187): do_action('wp_ajax_woocomm...')

```